### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test SqlParseTree
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/boxofyellow/SqlParseTree/security/code-scanning/1](https://github.com/boxofyellow/SqlParseTree/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` block specifying the least privilege needed by the workflow, either at the workflow (top) level or at the job level. Since the sample workflow only checks out code and runs tests—operations that only require read access to repository contents—we can safely add a top-level permissions block allowing just `contents: read`. This is typically added after the workflow name and event triggers. No other changes are necessary as the workflow does not appear to need additional privileges.

- Edit `.github/workflows/test.yml`
- After the `name:` and before `on:`, add:
  ```yaml
  permissions:
    contents: read
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
